### PR TITLE
Turn new lights on before turning off inactive ones to avoid whole-house-blink

### DIFF
--- a/Director-Series-Apps/Vacation-Lighting-Director/Vacation Lighting Director.groovy
+++ b/Director-Series-Apps/Vacation-Lighting-Director/Vacation Lighting Director.groovy
@@ -46,6 +46,7 @@ definition(
     name: "Vacation Lighting Director",
     namespace: "tslagle13",
     author: "Tim Slagle",
+    category: "My Apps",
     description: "Randomly turn on/off lights to simulate the appearance of a occupied home while you are away.",
     iconUrl: "http://icons.iconarchive.com/icons/custom-icon-design/mono-general-2/512/settings-icon.png",
     iconX2Url: "http://icons.iconarchive.com/icons/custom-icon-design/mono-general-2/512/settings-icon.png"
@@ -272,16 +273,14 @@ else if (modeOk) {
     switches.off()
 }
 //if none is ok turn off frequency check and turn off lights.
-else if(people){
+else if(people && anyoneIsHome()){
     //don't turn off lights if anyone is home
-		if(anyoneIsHome()){
-		log.debug("Stopping Check for Light")
-    	}
-        else{
+	log.debug("Stopping Check for Light")
+}
+else{
     log.debug("Stopping Check for Light and turning off all lights")
 	switches.off()
-    }
-}
+}    
 }    
 
 

--- a/Director-Series-Apps/Vacation-Lighting-Director/Vacation Lighting Director.groovy
+++ b/Director-Series-Apps/Vacation-Lighting-Director/Vacation Lighting Director.groovy
@@ -243,8 +243,6 @@ def modeChangeHandler(evt) {
 def scheduleCheck(evt) {
 if(allOk){
 log.debug("Running")
-  // turn off all the switches
-  switches.off()
 
   // grab a random switch
   def random = new Random()
@@ -262,6 +260,8 @@ log.debug("Running")
     // then remove that switch from the pool off switches that can be turned on
     inactive_switches.remove(random_int)
   }
+  // turn off remaining switches
+  inactive_switches.off()
 
   // re-run again when the frequency demands it
   runIn(frequency_minutes * 60, scheduleCheck)


### PR DESCRIPTION
IMHO it's more likely to look like the house is occupied if new lights come on before the old ones go off. Otherwise the whole house goes dark for a second or two -- an unlikely event if it were a person turning lights on and off. This is particularly noticeable if lights are randomly chosen to be ```on``` in both before and after segments.

Also fixed the case where ```people``` is blank. If the user leaves this field blank his intent would be that the lights should turn off on mode change even if anyone is home. This now does that (but only at the next schedule update after the mode change).

Finally, I added a category to the definitions. In my environment, anyway, the app won't run without this. 